### PR TITLE
Add --exclude argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ ego.go: template.ego
 
 files/files.go: ego.go static/*
 	@go get
-	staticfiles --build-tags="!dev" -o files/files.go static/
+	staticfiles --build-tags="!dev" --exclude="*.scss" -o files/files.go static/

--- a/static/style.scss
+++ b/static/style.scss
@@ -1,0 +1,12 @@
+html {
+  background-color: #ffffff;
+}
+body {
+  width: 500px;
+  font-family: sans-serif;
+  line-height: 1.5em;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 12.5%;
+  font-size: 15px;
+}

--- a/staticfiles.go
+++ b/staticfiles.go
@@ -77,7 +77,7 @@ func main() {
 	flag.StringVar(&outputFile, "o", "staticfiles.go", "File to write results to.")
 	flag.StringVar(&packageName, "package", "", "Package name of the resulting file. Defaults to name of the resulting file directory")
 	flag.StringVar(&buildTags, "build-tags", "", "Build tags to write to the file")
-	flag.StringVar(&excludeList, "exclude", "", "Comma-separated patterns to exclude. (e.g. *.scss, sass/ etc.)")
+	flag.StringVar(&excludeList, "exclude", "", "Comma-separated patterns to exclude. (e.g. '*.scss,templates/')")
 	flag.Parse()
 	if flag.NArg() != 1 {
 		log.Println("Please pass in a directory to process")


### PR DESCRIPTION
This is a part to address https://github.com/bouk/staticfiles/issues/4.

I have added `--exclude` argument to `staticfiles` command. This would be great for avoiding certain dirs/files (such as *.scss) which are not meant to be served.
 I did not implement `--files` argument because I thought that might make things a little confusing. 
